### PR TITLE
Add uv project metadata and installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,33 @@ This project exposes a small portion of the [Chinook sample database](https://gi
 
 ### Installation
 
+You can install the dependencies with either the built-in `venv` module or with
+the [uv](https://github.com/astral-sh/uv) package manager.  The uv workflow is
+recommended because it understands the `pyproject.toml` included in this
+repository and can resolve optional dependency groups in a single command.
+
+#### Using uv (recommended)
+
+1. Create the environment (this uses the Python from your `$PATH`):
+
+   ```bash
+   uv venv
+   source .venv/bin/activate
+   ```
+
+2. Install the application and development dependencies defined in
+   `pyproject.toml`:
+
+   ```bash
+   uv sync --all-groups
+   ```
+
+   The `--all-groups` flag installs the default runtime dependencies as well as
+   the optional development tools listed under `[tool.uv]` in
+   `pyproject.toml`.
+
+#### Using pip
+
 1. Create and activate a virtual environment:
 
    ```bash
@@ -25,7 +52,7 @@ This project exposes a small portion of the [Chinook sample database](https://gi
    source .venv/bin/activate
    ```
 
-2. Install the required dependencies:
+2. Install the required dependencies from `requirements.txt`:
 
    ```bash
    python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "chinook-service"
+version = "0.1.0"
+description = "Flask REST API for the Chinook sample database"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "Flask>=2.3.3,<3.0",
+    "Flask-RESTful>=0.3.10,<0.4",
+    "SQLAlchemy>=2.0.36,<3.0",
+    "yahoo_fin>=0.8.9.1,<0.9",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv]
+dev-dependencies = [
+    "pytest>=8.3.0,<9.0",
+    "pytest-cov>=5.0.0,<6.0",
+]


### PR DESCRIPTION
## Summary
- add a pyproject.toml so uv can manage the service dependencies
- document a uv-based workflow while keeping the existing pip instructions for convenience

## Testing
- python -m unittest discover -s tests -p "test_*.py" *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68d9a0e76de08324ab9052797915c64c